### PR TITLE
Escape underscores

### DIFF
--- a/doc/user_guide/user_guide.tex
+++ b/doc/user_guide/user_guide.tex
@@ -132,7 +132,7 @@ Follow the next steps to install RetDec plugin in a Linux environment:
 libc.so.6 libgcc_s.so.1 libm.so.6 libpthread.so.0 libstdc++.so.6
 \end{verbatim}
 	\item Download the Linux installation package (Table~\ref{table:installation-package-linux}) from the \href{https://github.com/avast-tl/retdec-idaplugin/releases}{project's release page}.
-	\item Copy \texttt{retdec.plx} to the IDA's plugin directory (\texttt{<IDA_root>/plugins}).
+	\item Copy \texttt{retdec.plx} to the IDA's plugin directory (\texttt{<IDA\_ROOT>/plugins}).
 \end{enumerate}
 
 \begin{table}[!ht]
@@ -157,7 +157,7 @@ The Windows version of the plugin requires Windows 7 or later, with the MSVC 201
 Follow the next steps to install RetDec plugin in a Windows environment:
 \begin{enumerate}
 	\item Download the Windows installation package (Table~\ref{table:installation-package-windows}) from the \href{https://github.com/avast-tl/retdec-idaplugin/releases}{project's release page}.
-	\item Copy \texttt{retdec.plw} to the IDA's plugin directory (\texttt{<IDA_root>/plugins}).
+	\item Copy \texttt{retdec.plw} to the IDA's plugin directory (\texttt{<IDA\_ROOT>/plugins}).
 \end{enumerate}
 
 \begin{table}[!ht]
@@ -189,7 +189,7 @@ This section describes how to configure RetDec plugin. After you follow these st
 \label{sec:config:plugin-cfg}
 The plugin's default mode is set to selective decompilation (see Section~\ref{sec:decompilation}). It tries to register hotkey \texttt{CTRL+D} for its invocation. If you already use this hotkey for another action or you just want to use a different hotkey, you need to modify IDA's plugin configuration file. Moreover, the plugin supports one more decompilation mode and a hotkey invocation for the plugin's configuration. If you want to use any of them, you also have to modify the config file.
 
-The IDA's plugin configuration file is in \texttt{<IDA_root>/plugins/plugins.cfg}. Its format is documented inside the file itself. To configure RetDec plugin, add the following lines at the beginning\footnote{Newer versions of IDA behave strangely when the lines are appended at the end, so just put them at the start.} of the file:
+The IDA's plugin configuration file is in \texttt{<IDA\_ROOT>/plugins/plugins.cfg}. Its format is documented inside the file itself. To configure RetDec plugin, add the following lines at the beginning\footnote{Newer versions of IDA behave strangely when the lines are appended at the end, so just put them at the start.} of the file:
 \begin{verbatim}
 ; Plugin_name           File_name Hotkey        Arg
 ; -------------------------------------------------


### PR DESCRIPTION
Needed for pandoc. (e.g. `pandoc -s user_guide.tex -o user_guide.html`)