### PR TITLE
Remove OpenSSL dependency for building

### DIFF
--- a/deps/retdec/CMakeLists.txt
+++ b/deps/retdec/CMakeLists.txt
@@ -3,6 +3,8 @@ include(ExternalProject)
 ExternalProject_Add(retdec-project
 	URL https://github.com/avast/retdec/archive/10c0ddcf5e0fdb8ee4c5256787a0fa74bd069883.zip
 	URL_HASH SHA256=2e2112ac8d5a31721c2cafe3d7657b13b5efaed9b22486e20fd2ac8de79a7311
+	# Disable the configure step.
+        CONFIGURE_COMMAND ""	
 	# Disable the update step.
 	UPDATE_COMMAND ""
 	# Disable the build step.


### PR DESCRIPTION
Remove configure for retdec - it is requiring OpenSSL and other dependencies which makes no sense for just building the plugin.

The whereami library is already included as source code and the CMakeLists.txt chain includes it via dependencies.  So no action is needed for that.  It seems to build just fine without the configure option without having to fetch OpenSSL.