### PR TITLE
Fix code viewer leaking/improve terminate handling

### DIFF
--- a/src/idaplugin/code_viewer.cpp
+++ b/src/idaplugin/code_viewer.cpp
@@ -1169,8 +1169,11 @@ void idaapi ct_close(TWidget* cv, void* ud)
 {
 	RdGlobalInfo* di = static_cast<RdGlobalInfo*>(ud);
 
-	di->custViewer = nullptr;
-	di->codeViewer = nullptr;
+	di->custViewer = nullptr; //==cv
+	if (di->codeViewer) {
+		close_widget(di->codeViewer, 0);
+		di->codeViewer = nullptr;
+	}
 }
 
 //

--- a/src/idaplugin/idaplugin.cpp
+++ b/src/idaplugin/idaplugin.cpp
@@ -699,11 +699,11 @@ void idaapi term()
 	killDecompilation();
 	if (decompInfo.custViewer) {
 		close_widget(decompInfo.custViewer, 0);
-		decompInfo->custViewer = nullptr;
+		decompInfo.custViewer = nullptr;
 	}
 	if (decompInfo.codeViewer) {
 		close_widget(decompInfo.codeViewer, 0);
-		decompInfo->codeViewer = nullptr;
+		decompInfo.codeViewer = nullptr;
 	}
 	unregister_action("retdec:ActionJumpToAsm");
 	unregister_action("retdec:ActionChangeFncGlobName");

--- a/src/idaplugin/idaplugin.cpp
+++ b/src/idaplugin/idaplugin.cpp
@@ -697,6 +697,26 @@ int idaapi init()
 void idaapi term()
 {
 	killDecompilation();
+	if (decompInfo->custViewer) {
+		close_widget(decompInfo->custViewer, 0);
+		decompInfo->custViewer = nullptr;
+	}
+	if (decompInfo->codeViewer) {
+		close_widget(decompInfo->codeViewer, 0);
+		decompInfo->codeViewer = nullptr;
+	}
+	unregister_action("retdec:ActionJumpToAsm");
+	unregister_action("retdec:ActionChangeFncGlobName");
+	unregister_action("retdec:ActionOpenXrefs");
+	unregister_action("retdec:ActionOpenCalls");
+	unregister_action("retdec:ActionChangeFncType");
+	unregister_action("retdec:ActionChangeFncComment");
+	unregister_action("retdec:ActionMoveForward");
+	unregister_action("retdec:ActionMoveBackward");
+	if (is_idaq) {
+		const char optionsActionName[] = "retdec:ShowOptions";
+		unregister_action(optionsActionName);
+	}
 	unhook_from_notification_point(HT_UI, ui_callback);
 }
 

--- a/src/idaplugin/idaplugin.cpp
+++ b/src/idaplugin/idaplugin.cpp
@@ -697,12 +697,12 @@ int idaapi init()
 void idaapi term()
 {
 	killDecompilation();
-	if (decompInfo->custViewer) {
-		close_widget(decompInfo->custViewer, 0);
+	if (decompInfo.custViewer) {
+		close_widget(decompInfo.custViewer, 0);
 		decompInfo->custViewer = nullptr;
 	}
-	if (decompInfo->codeViewer) {
-		close_widget(decompInfo->codeViewer, 0);
+	if (decompInfo.codeViewer) {
+		close_widget(decompInfo.codeViewer, 0);
 		decompInfo->codeViewer = nullptr;
 	}
 	unregister_action("retdec:ActionJumpToAsm");


### PR DESCRIPTION
The custom viewer is the parent and IDA does not close the tree for you.  It merely provides events for top level windows closing, and as for all the child widgets/viewers and such, one must manually close them to free the resources.  It took me some time to figure out exactly how this model works.  But I believe some simple changes will further make this resilient.