### PR TITLE
Fixes to compile with IDA 7.4 SDK

### DIFF
--- a/src/idaplugin/code_viewer.h
+++ b/src/idaplugin/code_viewer.h
@@ -121,7 +121,7 @@ struct ShowOutput : public exec_request_t
 
 		display_widget(
 				di->codeViewer,
-#if !defined(IDA_SDK_VERSION) || IDA_SDK_VERSION < 740
+#if IDA_SDK_VERSION < 730
 				WOPN_TAB |
 #else 
 				WOPN_DP_TAB |

--- a/src/idaplugin/code_viewer.h
+++ b/src/idaplugin/code_viewer.h
@@ -121,7 +121,12 @@ struct ShowOutput : public exec_request_t
 
 		display_widget(
 				di->codeViewer,
+#if !defined(IDA_SDK_VERSION) || IDA_SDK_VERSION < 740
 				WOPN_TAB |
+#else 
+				WOPN_DP_TAB |
+#endif
+
 #if !defined(IDA_SDK_VERSION) || IDA_SDK_VERSION < 720
 				WOPN_MENU |
 #endif

--- a/src/idaplugin/defs.h
+++ b/src/idaplugin/defs.h
@@ -7,6 +7,10 @@
 #ifndef IDAPLUGIN_DEFS_H
 #define IDAPLUGIN_DEFS_H
 
+#ifdef NO_OBSOLETE_FUNCS
+#undef NO_OBSOLETE_FUNCS
+#endif
+
 #include <iostream>
 #include <list>
 #include <map>

--- a/src/idaplugin/idaplugin.cpp
+++ b/src/idaplugin/idaplugin.cpp
@@ -404,7 +404,11 @@ bool canDecompileInput()
 	// 32-bit binary -> is_32bit() == 1 && is_64bit() == 0.
 	// 64-bit binary -> is_32bit() == 1 && is_64bit() == 1.
 	// Allow 64-bit x86.
+#if !defined(IDA_SDK_VERSION) || IDA_SDK_VERSION < 740
 	if ((!inf.is_32bit() || inf.is_64bit()) && !isX86())
+#else
+	if ((!inf_is_32bit() || inf_is_64bit()) && !isX86())
+#endif
 	{
 		WARNING_GUI(decompInfo.pluginName << " version " << decompInfo.pluginVersion
 				<< " can decompile only 32-bit input files.\n"
@@ -531,7 +535,13 @@ bool canDecompileInput()
 		}
 		else if (isX86())
 		{
+
+#if !defined(IDA_SDK_VERSION) || IDA_SDK_VERSION < 740
 			decompInfo.architecture = inf.is_64bit() ? "x86-64" : "x86";
+#else
+			decompInfo.architecture = inf_is_64bit() ? "x86-64" : "x86";
+#endif
+			
 			decompInfo.endian = "little";
 		}
 		else

--- a/src/idaplugin/idaplugin.cpp
+++ b/src/idaplugin/idaplugin.cpp
@@ -404,7 +404,7 @@ bool canDecompileInput()
 	// 32-bit binary -> is_32bit() == 1 && is_64bit() == 0.
 	// 64-bit binary -> is_32bit() == 1 && is_64bit() == 1.
 	// Allow 64-bit x86.
-#if !defined(IDA_SDK_VERSION) || IDA_SDK_VERSION < 740
+#if IDA_SDK_VERSION < 730
 	if ((!inf.is_32bit() || inf.is_64bit()) && !isX86())
 #else
 	if ((!inf_is_32bit() || inf_is_64bit()) && !isX86())
@@ -536,7 +536,7 @@ bool canDecompileInput()
 		else if (isX86())
 		{
 
-#if !defined(IDA_SDK_VERSION) || IDA_SDK_VERSION < 740
+#if IDA_SDK_VERSION < 730
 			decompInfo.architecture = inf.is_64bit() ? "x86-64" : "x86";
 #else
 			decompInfo.architecture = inf_is_64bit() ? "x86-64" : "x86";


### PR DESCRIPTION
These are the suggested fixes needed to compile the plugin for IDA 7.4, tested with latest VS Studio 2019.