### PR TITLE
Update RetDec project and provide c++17 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 
-project(retdec-idaplugin CXX)
+project(retdec-idaplugin CXX C)
 set(RELEASE_VERSION "0.9")
 
 # Set the default build type to 'Release'
@@ -10,7 +10,7 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
@@ -36,7 +36,7 @@ if(MSVC) # Windows
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DNOMINMAX")
 elseif(UNIX) # Linux or macOS
 	# Common options.
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Currently, we officially support only Windows and Linux. It may be possible to b
 
 **Note: These are requirements to build the RetDec IDA plugin, not to run it. See our [User Guide](https://github.com/avast/retdec-idaplugin/blob/master/doc/user_guide/user_guide.pdf) for information on plugin installation, configuration, and use.**
 
-* A compiler supporting C++14
-  * On Windows, only Microsoft Visual C++ is supported (version >= Visual Studio 2015).
+* A compiler supporting C++17
+  * On Windows, only Microsoft Visual C++ is supported (version >= Visual Studio 2017).
 * CMake (version >= 3.6)
 * IDA SDK (version == 7.0)
 
@@ -48,7 +48,7 @@ Currently, we officially support only Windows and Linux. It may be possible to b
 
 You must pass the following parameters to `cmake`:
 * `-DIDA_SDK_DIR=</path/to/idasdk>` to tell `cmake` where the IDA SDK directory is located.
-* (Windows only) `-G<generator>` is `-G"Visual Studio 14 2015 Win64"` for 64-bit build using Visual Studio 2015. Later versions of Visual Studio may be used. Only 64-bit build is supported.
+* (Windows only) `-G<generator>` is `-G"Visual Studio 15 2017 Win64"` for 64-bit build using Visual Studio 2017. Later versions of Visual Studio may be used. Only 64-bit build is supported.
 
 You can pass the following additional parameters to `cmake`:
 * `-DIDA_PATH=</path/to/ida>` to tell `cmake` where to install the plugin. If specified, installation will copy plugin binaries into `IDA_PATH/plugins`, and content of `scripts/idc` directory into `IDA_PATH/idc`. If not set, installation step does nothing.

--- a/deps/retdec/CMakeLists.txt
+++ b/deps/retdec/CMakeLists.txt
@@ -1,8 +1,8 @@
 include(ExternalProject)
 
 ExternalProject_Add(retdec-project
-	URL https://github.com/avast/retdec/archive/10c0ddcf5e0fdb8ee4c5256787a0fa74bd069883.zip
-	URL_HASH SHA256=2e2112ac8d5a31721c2cafe3d7657b13b5efaed9b22486e20fd2ac8de79a7311
+	URL https://github.com/avast/retdec/archive/b0240726975a6b1b58c41f0bdeef64686374bfe0.zip
+	URL_HASH SHA256=2c84409b56810378d83721655be1f913d72fd151963573dccdb5c4f04d5229d4
 	# Disable the configure step.
         CONFIGURE_COMMAND ""	
 	# Disable the update step.
@@ -20,42 +20,88 @@ ExternalProject_Add(retdec-project
 ExternalProject_Get_Property(retdec-project source_dir)
 ExternalProject_Get_Property(retdec-project binary_dir)
 
+set(RETDEC_SERDES_SOURCES
+	${source_dir}/src/serdes/address.cpp
+	${source_dir}/src/serdes/architecture.cpp
+	${source_dir}/src/serdes/basic_block.cpp
+	${source_dir}/src/serdes/calling_convention.cpp
+	${source_dir}/src/serdes/class.cpp
+	${source_dir}/src/serdes/file_format.cpp
+	${source_dir}/src/serdes/file_type.cpp
+	${source_dir}/src/serdes/function.cpp
+	${source_dir}/src/serdes/language.cpp
+	${source_dir}/src/serdes/object.cpp
+	${source_dir}/src/serdes/pattern.cpp
+	${source_dir}/src/serdes/std.cpp
+	${source_dir}/src/serdes/storage.cpp
+	${source_dir}/src/serdes/tool_info.cpp
+	${source_dir}/src/serdes/type.cpp
+	${source_dir}/src/serdes/utils.cpp
+	${source_dir}/src/serdes/vtable.cpp
+)
+set(RETDEC_COMMON_SOURCES
+	${source_dir}/src/common/address.cpp
+	${source_dir}/src/common/architecture.cpp
+	${source_dir}/src/common/basic_block.cpp
+	${source_dir}/src/common/calling_convention.cpp
+	${source_dir}/src/common/class.cpp
+	${source_dir}/src/common/file_format.cpp
+	${source_dir}/src/common/file_type.cpp
+	${source_dir}/src/common/function.cpp
+	${source_dir}/src/common/language.cpp
+	${source_dir}/src/common/object.cpp
+	${source_dir}/src/common/pattern.cpp
+	${source_dir}/src/common/storage.cpp
+	${source_dir}/src/common/tool_info.cpp
+	${source_dir}/src/common/type.cpp
+	${source_dir}/src/common/vtable.cpp
+)
 set(RETDEC_UTILS_SOURCES
-	${source_dir}/src/utils/address.cpp
 	${source_dir}/src/utils/alignment.cpp
 	${source_dir}/src/utils/byte_value_storage.cpp
+	${source_dir}/src/utils/binary_path.cpp
 	${source_dir}/src/utils/conversion.cpp
+	${source_dir}/src/utils/dynamic_buffer.cpp
 	${source_dir}/src/utils/file_io.cpp
 	${source_dir}/src/utils/filesystem_path.cpp
 	${source_dir}/src/utils/math.cpp
+	${source_dir}/src/utils/memory.cpp
 	${source_dir}/src/utils/string.cpp
 	${source_dir}/src/utils/system.cpp
 	${source_dir}/src/utils/time.cpp
 )
 set(RETDEC_CONFIG_SOURCES
-	${source_dir}/src/config/architecture.cpp
 	${source_dir}/src/config/base.cpp
-	${source_dir}/src/config/calling_convention.cpp
-	${source_dir}/src/config/classes.cpp
 	${source_dir}/src/config/config.cpp
-	${source_dir}/src/config/file_format.cpp
-	${source_dir}/src/config/file_type.cpp
-	${source_dir}/src/config/functions.cpp
-	${source_dir}/src/config/language.cpp
-	${source_dir}/src/config/objects.cpp
 	${source_dir}/src/config/parameters.cpp
-	${source_dir}/src/config/patterns.cpp
-	${source_dir}/src/config/segments.cpp
-	${source_dir}/src/config/storage.cpp
-	${source_dir}/src/config/tool_info.cpp
-	${source_dir}/src/config/types.cpp
-	${source_dir}/src/config/vtables.cpp
+)
+set(WHEREAMI_SOURCES
+	${source_dir}/deps/whereami/whereami.c
 )
 
-add_custom_command(OUTPUT ${RETDEC_UTILS_SOURCES} ${RETDEC_CONFIG_SOURCES} DEPENDS retdec-project)
+add_custom_command(OUTPUT
+	${RETDEC_SERDES_SOURCES}
+	${RETDEC_COMMON_SOURCES}
+	${RETDEC_UTILS_SOURCES}
+	${RETDEC_CONFIG_SOURCES}
+	${WHEREAMI_SOURCES}
+	DEPENDS retdec-project
+)
 
 # Add libraries.
-add_library(retdec ${RETDEC_UTILS_SOURCES} ${RETDEC_CONFIG_SOURCES})
+add_library(retdec
+	${RETDEC_SERDES_SOURCES}
+	${RETDEC_COMMON_SOURCES}
+	${RETDEC_UTILS_SOURCES}
+	${RETDEC_CONFIG_SOURCES}
+	${WHEREAMI_SOURCES}
+)
+
 add_dependencies(retdec retdec-project)
-target_include_directories(retdec PUBLIC ${source_dir}/include)
+target_include_directories(retdec PUBLIC
+	${source_dir}/include
+	${source_dir}/src
+	${source_dir}/deps
+	${source_dir}/deps/whereami
+)
 target_link_libraries(retdec jsoncpp)

--- a/src/idaplugin/code_viewer.cpp
+++ b/src/idaplugin/code_viewer.cpp
@@ -160,14 +160,14 @@ static bool get_current_word(
 bool isWordGlobal(const std::string& word, int color)
 {
 	return color == COLOR_DEFAULT
-			&& decompInfo.configDB.globals.getObjectByNameOrRealName(word)
+			&& decompInfo.configDB.globals.getObjectByName(word)
 					!= nullptr;
 }
 
-const retdec::config::Object* getWordGlobal(const std::string& word, int color)
+const retdec::common::Object* getWordGlobal(const std::string& word, int color)
 {
 	return !word.empty() && color == COLOR_DEFAULT
-			? decompInfo.configDB.globals.getObjectByNameOrRealName(word)
+			? decompInfo.configDB.globals.getObjectByName(word)
 			: nullptr;
 }
 
@@ -182,7 +182,7 @@ bool isWordIdentifier(const std::string& word, int color)
 	return color == COLOR_DREF;
 }
 
-const retdec::config::Function* getWordFunction(
+const retdec::common::Function* getWordFunction(
 		const std::string& word,
 		int color)
 {
@@ -275,7 +275,7 @@ void decompileFunction(
 		bool force = false,
 		bool forceDec = false)
 {
-	auto* globVar = decompInfo.configDB.globals.getObjectByNameOrRealName(
+	auto* globVar = decompInfo.configDB.globals.getObjectByName(
 			calledFnc);
 
 	if (globVar && globVar->getStorage().isMemory())
@@ -555,8 +555,8 @@ bool idaapi changeFunctionGlobalName(TWidget* cv)
 
 	std::string askString;
 	ea_t address;
-	const retdec::config::Function* fnc = nullptr;
-	const retdec::config::Object* gv = nullptr;
+	const retdec::common::Function* fnc = nullptr;
+	const retdec::common::Object* gv = nullptr;
 	if ((fnc = getWordFunction(word, color)))
 	{
 		askString = "Please enter function name";
@@ -595,7 +595,7 @@ bool idaapi changeFunctionGlobalName(TWidget* cv)
 			+ SCOLOR_OFF
 			+ ".");
 
-	if (decompInfo.configDB.globals.getObjectByNameOrRealName(newName) != nullptr
+	if (decompInfo.configDB.globals.getObjectByName(newName) != nullptr
 			|| decompInfo.configDB.functions.hasFunction(newName)
 			|| std::regex_search(fit->second.code, e))
 	{
@@ -955,8 +955,8 @@ bool idaapi ct_keyboard(TWidget* cv, int key, int shift, void* ud)
 		return false;
 	}
 	auto* idaFnc = getIdaFunction(word, color);
-	const retdec::config::Function* cFnc = getWordFunction(word, color);
-	const retdec::config::Object* cGv = getWordGlobal(word, color);
+	const retdec::common::Function* cFnc = getWordFunction(word, color);
+	const retdec::common::Object* cGv = getWordGlobal(word, color);
 
 	// 45 = INSERT
 	// 186 = ';'
@@ -1065,8 +1065,8 @@ ssize_t idaapi ui_callback(void* ud, int notification_code, va_list va)
 			}
 
 			auto* idaFnc = getIdaFunction(word, color);
-			const retdec::config::Function* cFnc = getWordFunction(word, color);
-			const retdec::config::Object* cGv = getWordGlobal(word, color);
+			const retdec::common::Function* cFnc = getWordFunction(word, color);
+			const retdec::common::Object* cGv = getWordGlobal(word, color);
 
 			TPopupMenu* p = va_arg(va, TPopupMenu*);
 

--- a/src/idaplugin/config_generator.h
+++ b/src/idaplugin/config_generator.h
@@ -29,14 +29,14 @@ class ConfigGenerator
 		void generateFunctions();
 		void generateFunctionType(
 				const tinfo_t& fncType,
-				retdec::config::Function& ccFnc);
-		void generateSegmentsAndGlobals();
-		retdec::config::Storage generateObjectLocation(
+				retdec::common::Function& ccFnc);
+		void generateGlobals();
+		retdec::common::Storage generateObjectLocation(
 				const argloc_t& loc,
 				const tinfo_t& locType);
 		void generateCallingConvention(
 				const cm_t &idaCC,
-				retdec::config::CallingConvention &configCC);
+				retdec::common::CallingConvention &configCC);
 
 		std::string addrType2string(ea_t addr);
 		std::string type2string(const tinfo_t &type);

--- a/src/idaplugin/defs.h
+++ b/src/idaplugin/defs.h
@@ -39,7 +39,7 @@
 // RetDec includes.
 //
 #include "retdec/config/config.h"
-#include "retdec/utils/address.h"
+#include "retdec/common/address.h"
 #include "retdec/utils/filesystem_path.h"
 #include "retdec/utils/os.h"
 #include "retdec/utils/time.h"
@@ -124,8 +124,8 @@ class RdGlobalInfo
 		std::string mode;
 		std::string architecture;
 		std::string endian;
-		retdec::utils::Address rawEntryPoint;
-		retdec::utils::Address rawSectionVma;
+		retdec::common::Address rawEntryPoint;
+		retdec::common::Address rawSectionVma;
 
 		std::map<func_t*, FunctionInfo> fnc2code;
 		std::list<func_t*> navigationList;

--- a/src/idaplugin/idaplugin.cpp
+++ b/src/idaplugin/idaplugin.cpp
@@ -450,8 +450,8 @@ bool canDecompileInput()
 	decompInfo.mode.clear();
 	decompInfo.architecture.clear();
 	decompInfo.endian.clear();
-	decompInfo.rawEntryPoint = retdec::utils::Address();
-	decompInfo.rawSectionVma = retdec::utils::Address();
+	decompInfo.rawEntryPoint = retdec::common::Address();
+	decompInfo.rawSectionVma = retdec::common::Address();
 
 	// Check Intel HEX.
 	//


### PR DESCRIPTION
Update RetDec project and provide c++17 support

* Provides update of the RetDec external project.
  There was a major update on the side of retdec-config library
  that is used in this project to generate input configuration
  for the decompiler. This commit brings reflection of such
  changes into retdec-idaplugin.

  - Library retdec::config was split into more parts.
  - Most of the classes in namespace ::utils and ::conifg were
    moved to the namespace ::common.
  - Library retdec-config is now dependant on `whereami` project
    and this dependency needs to be addressed in `CMakeLists.txt`.

* "segments" support was removed from the configuration JSON.
  Method `generateSegmentsAndGlobals` in the `config_generator.h` file
  now generates only global data and was renamed to `generateGlobals`.